### PR TITLE
Update queries.R

### DIFF
--- a/R/queries.R
+++ b/R/queries.R
@@ -35,7 +35,7 @@
 #' @export
 query_wikidata <- function(sparql_query,format="simple",...) {
   output <- WikidataQueryServiceR::query_wikidata(sparql_query=sparql_query,format=format,...)
-  output <- suppressWarnings(mapply(url_to_id,data.frame(output)))
+  output <- suppressWarnings(mapply(url_to_id,data.frame(output), SIMPLIFY = FALSE))
   output <- tibble(data.frame(output))
   if(nrow(output)==0){output <- tibble(value=NA)}
   output


### PR DESCRIPTION
if the query returns 1 row result, it was reduced to a character vector, which caused a trouble when working via map_df(~query_wikidata(.x))