### PR TITLE
Introduce distinct language parameters for search and response

### DIFF
--- a/R/gets.R
+++ b/R/gets.R
@@ -156,16 +156,16 @@ get_example <- function(example_name){
 #'@aliases find_item find_property
 #'@rdname find_item
 #'@export
-find_item <- function(search_term, language = "en", limit = 10, ...){
-  res <- searcher(search_term, language, limit, "item")
+find_item <- function(search_term, language = "en", limit = 10, response_language = "en", ...){
+  res <- searcher(search_term, language, limit, response_language, "item")
   class(res) <- "find_item"
   return(res)
 }
 
 #'@rdname find_item
 #'@export
-find_property <- function(search_term, language = "en", limit = 10){
-  res <- searcher(search_term, language, limit, "property")
+find_property <- function(search_term, language = "en", response_language = "en", limit = 10){
+  res <- searcher(search_term, language, limit, response_language, "property")
   class(res) <- "find_property"
   return(res)
 }
@@ -174,7 +174,9 @@ find_property <- function(search_term, language = "en", limit = 10){
 #'@title Convert an input to a item QID
 #'@description Convert an input string to the most likely item QID
 #'@param search_term a term to search for.
-#'@param language the language to return the labels and descriptions in; this should
+#'@param language the language to conduct the search in; this should
+#'consist of an ISO language code. Set to "en" by default.
+#'@param response_language the language to return the labels and descriptions in; this should
 #'consist of an ISO language code. Set to "en" by default.
 #'@param limit the number of results to return; set to 10 by default.
 #'@param type type of wikidata object to return (default = "item")
@@ -190,12 +192,13 @@ find_property <- function(search_term, language = "en", limit = 10){
 #'# if input string matches a single unique label
 #'as_qid("Douglas Adams and the question of arterial blood pressure in mammals")
 #'@export
-searcher <- function(search_term, language, limit, type, ...){
+searcher <- function(search_term, language, limit, response_language, type, ...){
   result <- WikipediR::query(url = "https://www.wikidata.org/w/api.php", out_class = "list", clean_response = FALSE,
                              query_param = list(
                                action   = "wbsearchentities", 
                                type     = type,
                                language = language,
+                               uselang = response_language,
                                limit    = limit,
                                search   = search_term
                              ),

--- a/man/find_item.Rd
+++ b/man/find_item.Rd
@@ -5,9 +5,20 @@
 \alias{find_property}
 \title{Search for Wikidata items or properties that match a search term}
 \usage{
-find_item(search_term, language = "en", limit = 10, ...)
+find_item(
+  search_term,
+  language = "en",
+  limit = 10,
+  response_language = "en",
+  ...
+)
 
-find_property(search_term, language = "en", limit = 10)
+find_property(
+  search_term,
+  language = "en",
+  response_language = "en",
+  limit = 10
+)
 }
 \arguments{
 \item{search_term}{a term to search for.}

--- a/man/searcher.Rd
+++ b/man/searcher.Rd
@@ -4,15 +4,18 @@
 \alias{searcher}
 \title{Convert an input to a item QID}
 \usage{
-searcher(search_term, language, limit, type, ...)
+searcher(search_term, language, limit, response_language, type, ...)
 }
 \arguments{
 \item{search_term}{a term to search for.}
 
-\item{language}{the language to return the labels and descriptions in; this should
+\item{language}{the language to conduct the search in; this should
 consist of an ISO language code. Set to "en" by default.}
 
 \item{limit}{the number of results to return; set to 10 by default.}
+
+\item{response_language}{the language to return the labels and descriptions in; this should
+consist of an ISO language code. Set to "en" by default.}
 
 \item{type}{type of wikidata object to return (default = "item")}
 


### PR DESCRIPTION
In both `find_item` and `find_property` there is currently only one language parameter. In spite of what the current documentation suggests, this is not "the language to return the labels and descriptions in", but rather the language in which the search is conducted. Indeed, labels and description are currently always returned in English, no matter what language is set to. 

Search language is important, as the same string gives different results when searching in a different language. However, having the label and description *always* in English may be undesirable.

With this pull request, I suggest introducing a new parameter, `response_language`, to define this aspect. The API call this "uselang", which you may prefer. Indeed, the `wbsearchentities` API have a `language` and a `uselang` parameter, see: https://www.wikidata.org/w/api.php?action=help&modules=wbsearchentities

> language   Search in this language. This only affects how entities are selected, not the language in which the results are returned: this is controlled by the "uselang" parameter. 

See below reprex that illustrates the difference:

``` r
library("WikidataR")
search_string <- "San Francesco"

# search in English, return labels and description in English (default)
find_item(search_string, "en")
#> 
#>  Wikidata item search
#> 
#> Number of results:    10 
#> 
#> Results:
#> 1     San Francesco (Q1174762) - Wikimedia disambiguation page 
#> 2     San Francesco (Q672894) - minor basilica in Bologna, Italy 
#> 3     San Francesco (Q3670083) - church in Pisa, Italy 
#> 4     Francis of Assisi (Q676555) - Italian Catholic saint, friar, deacon and preacher and founder of the Franciscan Order (1181/2–1226) 
#> 5     San Francesco (Q3670054) - church in Grosseto 
#> 6     San Francesco (Q3670107) - church in Volterra, Tuscany, Italy 
#> 7     San Francesco (Q3585331) - church building in Città di Castello, Italy 
#> 8     San Francesco (Q52989040) - school in Aosta in the province of Aosta (Italy) [school id: AOIP001000] 
#> 9     San Francesco (Q2341041) - church in Treviso 
#> 10    San Francesco (Q25051590) - church in Matelica, Italy


# search in Italian (see different result order), but still return label and description in English
find_item(search_string, "it")
#> 
#>  Wikidata item search
#> 
#> Number of results:    10 
#> 
#> Results:
#> 1     Francis of Assisi (Q676555) - Italian Catholic saint, friar, deacon and preacher and founder of the Franciscan Order (1181/2–1226) 
#> 2     San Francesco (Q1174762) - Wikimedia disambiguation page 
#> 3     Liganj (Q3238434) 
#> 4     San Francesco (Q52989040) - school in Aosta in the province of Aosta (Italy) [school id: AOIP001000] 
#> 5     San Francesco (Q25051590) - church in Matelica, Italy 
#> 6     Saint Francis (Q15588902) - painting attributed to Cimabue 
#> 7     San Francesco (Q3947085) - painting by Carlo Crivelli 
#> 8     San Francesco (Q18487343) - human settlement in Italy 
#> 9     St Francis (Q22337548) - painting by Bernardo Strozzi 
#> 10    Saint Francis of Assisi (Q23929176) - painting by Raphael

# search in Italian, return label and description in Italian
find_item(search_string, "it", response_language = "it")
#> 
#>  Wikidata item search
#> 
#> Number of results:    10 
#> 
#> Results:
#> 1     Francesco d'Assisi (Q676555) - religioso, santo e poeta italiano 
#> 2     San Francesco (Q1174762) - pagina di disambiguazione di un progetto Wikimedia 
#> 3     San Francesco del Carnaro (Q3238434) - frazione del comune croato di Laurana 
#> 4     San Francesco (Q52989040) - istituto comprensivo di Aosta in provincia di Aosta (Italia) [codice scuola: AOIP001000] 
#> 5     San Francesco (Q25051590) - chiesa in Matelica 
#> 6     San Francesco (Q15588902) - dipinto di Cimabue 
#> 7     San Francesco (Q3947085) - dipinto di Carlo Crivelli conservato nel Museo reale delle belle arti del Belgio a Bruxelles 
#> 8     San Francesco (Q18487343) - frazione di Pelago 
#> 9     San Francesco (Q22337548) - dipinto di Bernardo Strozzi 
#> 10    San Francesco (Q23929176) - dipinto di Raffaello
```

<sup>Created on 2022-03-09 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>