### PR TITLE
Many spelling and code readability improvements.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -13,10 +13,10 @@ Authors@R: c(
            )
 Description: Read from, interrogate, and write to Wikidata <https://www.wikidata.org> -
     the multilingual, interdisciplinary, semantic knowledgebase. Includes functions to:
-    read from wikidata (single items, properties, or properties); query wikidata (retrieving
+    read from Wikidata (single items, properties, or properties); query Wikidata (retrieving
     all items that match a set of criteria via Wikidata SPARQL query service); write to
     Wikidata (adding new items or statements via QuickStatements); and handle and manipulate
-    Wikidata objects (as lists and tibbles). Uses the Wikidata and Quickstatements APIs. 
+    Wikidata objects (as lists and tibbles). Uses the Wikidata and QuickStatements APIs. 
 BugReports: https://github.com/TS404/WikidataR/issues
 URL: https://github.com/TS404/WikidataR
 License: MIT + file LICENSE
@@ -40,7 +40,9 @@ Suggests:
     testthat,
     tidyverse,
     knitr,
-    pageviews
-RoxygenNote: 7.1.2
+    pageviews,
+    spelling
+RoxygenNote: 7.2.3
 Encoding: UTF-8
 Depends: R (>= 3.5.0)
+Language: en-US

--- a/R/data.R
+++ b/R/data.R
@@ -4,7 +4,7 @@
 #'
 #' @description A dataset of Wikidata global variables.
 #'
-#' @format A list of tibbles documenting key property constraints from wikidata  
+#' @format A list of tibbles documenting key property constraints from Wikidata  
 #' \describe{
 #'   \item{SID.valid}{valid reference source properties}
 #'   \item{PID.datatype}{required data type for each property}

--- a/R/disambiguators.R
+++ b/R/disambiguators.R
@@ -3,8 +3,8 @@
 #'@title Disambiguate QIDs
 #'@description Interactive function that presents alternative possible QID matches for a list of text
 #'strings and provides options for choosing between alternatives, rejecting all presented alternatives,
-#'or creating new items. Useful in cases where a list of text strings may have either missing wikidata items
-#'or multiple alternative potential matches that need to be manually disambuguated. Can also used on
+#'or creating new items. Useful in cases where a list of text strings may have either missing Wikidata items
+#'or multiple alternative potential matches that need to be manually disambiguated. Can also used on
 #'lists of lists (see examples). For long lists of items, the process can be stopped partway through and
 #'the returned vector will indicate where the process was stopped. 
 #'@param list a list or vector of text strings to find potential QID matches to.
@@ -17,7 +17,7 @@
 #'                       (default = FALSE, note: true is slower if filter not needed on most matches)
 #'@param Q_min return only possible hits with QIDs above the provided value
 #'@param auto_create if no match found, automatically assign "CREATE"
-#'@param limit number of alternative possible wikidata items to present if multiple potential matches
+#'@param limit number of alternative possible Wikidata items to present if multiple potential matches
 #'@return a vector of:
 #' \describe{
 #'   \item{QID}{Selected QID (for when an appropriate Wikidata match exists)}

--- a/R/geo.R
+++ b/R/geo.R
@@ -16,7 +16,7 @@
 #'
 #'@param limit the maximum number of results to return.
 #'
-#'@param \\dots further arguments to pass to httr's GET.
+#'@param \\dots further arguments to pass to de{httr:ink[httr::GET]{GET}}.
 #'
 #'@return a data.frame of 5 columns:
 #'\itemize{
@@ -112,7 +112,7 @@ get_geo_entity <- function(entity, language = "en", radius = NULL, limit=100, ..
 #'@param language the two-letter language code to use for the name
 #'of the item. "en" by default.
 #'
-#'@param \\dots further arguments to pass to httr's GET.
+#'@param \\dots further arguments to pass to de{httr:ink[httr::GET]{GET}}.
 #'
 #'@return a data.frame of 5 columns:
 #'\itemize{

--- a/R/gets.R
+++ b/R/gets.R
@@ -9,10 +9,10 @@
 #'@param id the ID number(s) of the item or property you're looking for. This can be in
 #'various formats; either a numeric value ("200"), the full name ("Q200") or
 #'even with an included namespace ("Property:P10") - the function will format
-#'it appropriately. This function is vectorised and will happily accept
+#'it appropriately. This function is vectorized and will happily accept
 #'multiple IDs.
 #'
-#'@param \\dots further arguments to pass to httr's GET.
+#'@param \\dots further arguments to pass to de{httr:ink[httr::GET]{GET}}.
 #'
 #'@seealso \code{\link{get_random}} for selecting a random item or property,
 #'or \code{\link{find_item}} for using search functionality to pull out
@@ -57,7 +57,7 @@ get_property <- function(id, ...){
 #'
 #'@param limit how many random items to return. 1 by default, but can be higher.
 #'
-#'@param \\dots arguments to pass to httr's GET.
+#'@param \\dots arguments to pass to de{httr:ink[httr::GET]{GET}}.
 #'
 #'@seealso \code{\link{get_item}} for selecting a specific item or property,
 #'or \code{\link{find_item}} for using search functionality to pull out
@@ -129,18 +129,18 @@ get_example <- function(example_name){
 
 #'@title Search for Wikidata items or properties that match a search term
 #'@description \code{find_item} and \code{find_property} allow you to retrieve a set
-#'of Wikidata items or properties where the aliase or descriptions match a particular
+#'of Wikidata items or properties where the aliases or descriptions match a particular
 #'search term.  As with other \code{WikidataR} code, custom print methods are available;
 #'use \code{\link{str}} to manipulate and see the underlying structure of the data.
 #'
-#'@param search_term a term to search for.
+#'@param search_term A term to search for.
 #'
-#'@param language the language to return the labels and descriptions in; this should
-#'consist of an ISO language code. Set to "en" by default.
+#'@param language The language to return the labels and descriptions in; this should
+#'consist of an ISO language code. Defaults to \code{"en"}.
 #'
-#'@param limit the number of results to return; set to 10 by default.
+#'@param limit The number of results to return; set to \code{10} by default.
 #'
-#'@param \\dots further arguments to pass to httr's GET.
+#'@param \\dots further arguments to pass to de{httr:ink[httr::GET]{GET}}.
 #'
 #'@seealso \code{\link{get_random}} for selecting a random item or property,
 #'or \code{\link{get_item}} for selecting a specific item or property.
@@ -154,9 +154,14 @@ get_example <- function(example_name){
 #'peerage_props <- find_property("peerage")
 #'
 #'@aliases find_item find_property
+#'@return A list containing the result of the query.
 #'@rdname find_item
 #'@export
-find_item <- function(search_term, language = "en", limit = 10, response_language = "en", ...){
+find_item <- function(search_term, 
+                      language = "en", 
+                      limit = 10, 
+                      response_language = "en", 
+                      ...){
   res <- searcher(search_term, language, limit, response_language, "item")
   class(res) <- "find_item"
   return(res)
@@ -164,7 +169,10 @@ find_item <- function(search_term, language = "en", limit = 10, response_languag
 
 #'@rdname find_item
 #'@export
-find_property <- function(search_term, language = "en", response_language = "en", limit = 10){
+find_property <- function(search_term, 
+                          language = "en", 
+                          response_language = "en", 
+                          limit = 10){
   res <- searcher(search_term, language, limit, response_language, "property")
   class(res) <- "find_property"
   return(res)

--- a/R/prints.R
+++ b/R/prints.R
@@ -114,7 +114,7 @@ wd_print_base <- function(x, ...){
 #'
 #'@description print found objects generally.
 #'
-#'@param x wikidata object from get_item, get_random_item, get_property or get_random_property
+#'@param x Wikidata object from get_item, get_random_item, get_property or get_random_property
 #'@param \dots Arguments to be passed to methods
 #'@seealso get_item, get_random_item, get_property or get_random_property
 #'@method print wikidata

--- a/R/queries.R
+++ b/R/queries.R
@@ -1,13 +1,16 @@
 #Generic queryin' function for direct Wikidata calls. Wraps around WikipediR::page_content. - Ironholds
 #'@title Download a Wikidata item
-#'@description Utility wrapper for wikidata API to download item.
-#'Used by \code{get_item} and \code{get_property}
-#'@param title the wikidata item or property as a string
-#'@param \\dots Additional parameters to supply to [httr::POST]
-#'@return a download of the full wikidata object (item or property) formatted as a nested json list
+#'@description Utility wrapper for Wikidata API to download item.
+#'Used by \code{get_item} and \code{get_property}.
+#'@param title The Wikidata item or property as a string.
+#'@param \\dots Additional parameters to supply to  \code{httr:\link[httr::POST]{POST}}.
+#'@return A downloaded full wikidata object (item or property) formatted as a 
+#'nested json list.
 #'@export
 wd_query <- function(title, ...){
-  result <- WikipediR::page_content(domain = "wikidata.org", page_name = title, as_wikitext = TRUE,
+  result <- WikipediR::page_content(domain = "wikidata.org", 
+                                    page_name = title, 
+                                    as_wikitext = TRUE,
                                     httr::user_agent("WikidataR - https://github.com/TS404/WikidataR"),
                                     ...)
   output <- jsonlite::fromJSON(result$parse$wikitext[[1]])
@@ -16,14 +19,19 @@ wd_query <- function(title, ...){
 
 # Query for a random item in "namespace" (ns). Essentially a wrapper around WikipediR::random_page. - Ironholds
 #'@title Download random Wikidata items
-#'@description Utility wrapper for wikidata API to download random items. Used by \code{random_item}
-#'@param ns string indicating namespace, most commonly "Main" for QID items, "Property" for PID properties
-#'@param limit how many random objesct to return
-#'@param \\dots Additional parameters to supply to [httr::POST]
-#'@return a download of the full wikidata objects (items or properties) formatted as nested json lists
+#'@description Utility wrapper for Wikidata API to download random items. 
+#'Used by \code{random_item}.
+#'@param ns string indicating namespace, most commonly "Main" for QID items, "Property" 
+#'for PID properties.
+#'@param limit How many random object to return.
+#'@param \\dots Additional parameters to supply to  \code{httr:\link[httr::POST]{POST}}.
+#'@return Downloaded full wikidata objects (items or properties) formatted 
+#'as nested json lists.
 #'@export
 wd_rand_query <- function(ns, limit, ...){
-  result <- WikipediR::random_page(domain = "wikidata.org", as_wikitext = TRUE, namespaces = ns,
+  result <- WikipediR::random_page(domain = "wikidata.org", 
+                                   as_wikitext = TRUE, 
+                                   namespaces = ns,
                                    httr::user_agent("WikidataR - https://github.com/TS404/WikidataR"),
                                    limit = limit, ...)
   output <- lapply(result, function(x){jsonlite::fromJSON(x$wikitext[[1]])})
@@ -31,12 +39,12 @@ wd_rand_query <- function(ns, limit, ...){
   return(output)
 }
 
-#sparql query function for direct Wikidata calls.
-#'@title Download full Wikidata items matching a sparql query 
-#'@description Utility wrapper for wikidata spargle endpoint to download items.
-#'Used by \code{get_geo_entity} and \code{get_geo_box}
-#'@param query the sparql query as a string
-#'@param \\dots Additional parameters to supply to [httr::POST]
+#SPARQL query function for direct Wikidata calls.
+#'@title Download full Wikidata items matching a SPARQL query 
+#'@description Utility wrapper for wikidata spargl endpoint to download items.
+#'Used by \code{get_geo_entity} and \code{get_geo_box}.
+#'@param query The SPARQL query as a string
+#'@param \\dots Additional parameters to supply to \code{httr:\link[httr::POST]{POST}}.
 #'@return a download of the full wikidata objects formatted as a nested json list
 #'@export
 sparql_query <- function(query, ...){
@@ -56,8 +64,8 @@ sparql_query <- function(query, ...){
 #'   `tibble` (default) returns a pure character data frame,
 #'   `simple` returns a pure character vector, while
 #'   `smart` fetches JSON-formatted data and returns a tibble with datetime
-#'   columns converted to `POSIXct`
-#' @param \\dots Additional parameters to supply to [httr::POST]
+#'   columns converted to `POSIXct`.
+#' @param \\dots Additional parameters to supply to \code{httr:\link[httr::POST]{POST}}.
 #' @return A `tibble` or `vector`. Note: QID values will be returned as QIDs, rather than URLs.
 #' @section Query limits:
 #' There is a hard query deadline configured which is set to 60 seconds. There
@@ -65,8 +73,8 @@ sparql_query <- function(query, ...){
 #' - One client (user agent + IP) is allowed 60 seconds of processing time each
 #'   60 seconds
 #' - One client is allowed 30 error queries per minute
-#' See [query limits section](https://www.mediawiki.org/wiki/Wikidata_Query_Service/User_Manual#Query_limits)
-#' in the WDQS user manual for more information.
+#' See \href{https://www.mediawiki.org/wiki/Wikidata_Query_Service/User_Manual#Query_limits}{query limits section}
+#' in the Wikidata Query Service User Manual for more information.
 #' @examples
 #' # R's versions and release dates:
 #' sparql_query <- 'SELECT DISTINCT
@@ -88,18 +96,23 @@ sparql_query <- function(query, ...){
 query_wikidata <- function(sparql_query,format="tibble",...) {
   if(format=="simple"){simplify<-TRUE}else{simplify<-FALSE}
   if(format=="tibble"){format<-"simple"}
-  output <- WikidataQueryServiceR::query_wikidata(sparql_query=sparql_query,format=format,...)
-  output <- suppressWarnings(mapply(url_to_id,data.frame(output),SIMPLIFY=simplify))
+  output <- WikidataQueryServiceR::query_wikidata(sparql_query=sparql_query,
+                                                  format=format, ...)
+  output <- suppressWarnings(mapply(url_to_id,
+                                    data.frame(output),
+                                    SIMPLIFY=simplify))
   output <- tibble(data.frame(output))
   if(nrow(output)==0){output<-tibble(value=NA)}
   output
 }
 
 #' @title QID from identifier
-#' @description convert unique identifiers to QIDs (for items in wikidata). 
-#' @param property the identifier property to search (for caveats, see \code{as_pid})
-#' @param value the identifier value to match
-#' @return vector of QIDs corresponding to identifiers submitted
+#' @description Convert unique identifiers to QIDs (for items in Wikidata). 
+#' @details The \href{https://www.wikidata.org/wiki/Q43649390}{Wikidata Q identifier} (QID) is the unique identifier (UID) 
+#' used in Wikidata.
+#' @param property The identifier property to search (for caveats, see \code{as_pid}.)
+#' @param value The identifier value to match.
+#' @return A vector of QIDs corresponding to identifiers submitted.
 #' @examples
 #' qid_from_identifier('ISBN-13','978-0-262-53817-6')
 #' @export
@@ -108,38 +121,50 @@ qid_from_identifier <- function(property = 'DOI',
   
   property <- as_pid(property)
   
-  qid_from_property1 <- function(value,property){out <- paste('SELECT ?value WHERE {?value wdt:',
-                                                       property,
-                                                       ' "',
-                                                       value,
-                                                       '"}',
-                                                       sep='')
-                                                 names(out)<-value
-                                                 return(out)}
- 
-  qid_from_property2 <- function(x){out <- as.character(query_wikidata(x)[[1]])
-                                    names(out) <- names(x)
-                                    return(out)}
-    
+  qid_from_property1 <- function(value,property){
+    out <- paste('SELECT ?value WHERE {?value wdt:',
+                 property,
+                 ' "',
+                 value,
+                 '"}',
+                 sep='')
+    names(out)<-value
+    return(out)
+    }
+  
+  qid_from_property2 <- function(x){
+    out <- as.character(query_wikidata(x)[[1]])
+    names(out) <- names(x)
+    return(out)
+    }
+  
   sparql_query <- lapply(value,property,FUN=qid_from_property1)
+  
   if(length(value)>1){
     output <- unlist(pblapply(sparql_query,qid_from_property2))
-  }else{
+  } else {
     output <- as.character(unlist(lapply(sparql_query,FUN=query_wikidata)))
     names(output) <- value
   }
-  if(length(value)!=length(output)){message("Caution! Some supplied values returned more than one QID.")}
+  
+  if(length(value)!=length(output)){
+    message("Caution! Some supplied values returned more than one QID.")
+    }
+  
   return(output)
 }
 
-#' @title identifier from identifier
-#' @description convert unique identifiers to other unique identifiers 
-#' @param property the identifier property to search (for caveats, see \code{as_pid})
-#' @param return the identifier property to convert to
-#' @param value the identifier value to match
-#' @return vector of identifiers corresponding to identifiers submitted
+#' @title Identifier from identifier
+#' @description Convert unique identifiers to other unique identifiers.
+#' @param property The identifier property to search (for caveats, see \code{as_pid})
+#' @param return The identifier property to convert to
+#' @param value The identifier value to match.
+#' @return A vector of identifiers corresponding to identifiers submitted.
 #' @examples
-#' identifier_from_identifier('ORCID iD','IMDb ID',c('0000-0002-7865-7235','0000-0003-1079-5604'))
+#' identifier_from_identifier(property ='ORCID iD',
+#'                            return = 'IMDb ID',
+#'                            value = c('0000-0002-7865-7235','0000-0003-1079-5604')
+#'                            )
 #' @export
 identifier_from_identifier <- function(property = 'ORCID iD',
                                        return   = 'IMDb ID',

--- a/R/schol.R
+++ b/R/schol.R
@@ -1,5 +1,5 @@
 #' @title QID from DOI
-#' @description simple converter from DOIs to QIDs (for items in wikidata)
+#' @description simple converter from DOIs to QIDs (for items in Wikidata)
 #' @param DOI digital object identifiers submitted as strings
 #' @return vector of QIDs corresponding to DOIs submitted
 #' @export

--- a/R/utils.R
+++ b/R/utils.R
@@ -66,9 +66,10 @@ check_input <- function(input, substitution){
 
 # -------- Format converters --------
 # Simple functions to convert plain text descriptions into their most likely QID/PIDs
-#'@title Convert an input to a item QID
-#'@description Convert an input string to the most likely item QID
-#'@param x a vector, data frame, or tibble of strings representaing wikidata items
+#'@title Convert an input to a item QID.
+#'@description Convert an input string to the most likely item 
+#'\href{https://www.wikidata.org/wiki/Q43649390}{QID}.
+#'@param x a vector, data frame, or tibble of strings representing wikidata items
 #'@return if the inputted string is a valid QID, return the string.
 #'If the inputted string matches an item label, return its QID.
 #'If the inputted string matches multiple labels of multiple items, return the QID of the first hit.
@@ -121,8 +122,8 @@ as_qid <- function(x){
 
 #'@title Convert an input to a property PID
 #'@description Convert an input string to the most likely property PID
-#'@param x a vector, data frame, or tibble of strings representaing wikidata properties
-#'@return if the inputted string is a valid PID, return the string.
+#'@param x a vector, data frame, or tibble of strings representing Wikidata properties
+#'@return If the inputted string is a valid PID, return the string.
 #'If the inputted string matches a property label, return its PID.
 #'If the inputted string matches multiple labels of multiple properties, return the PID of the first hit.
 #'@examples
@@ -162,11 +163,14 @@ as_pid <- function(x){
 }
 
 #'@title Convert an input to a source property SID
-#'@description Convert an input string to the most likely source SID (equivalent to PID)
-#'@param x a vector, data frame, or tibble of strings representaing wikidata source properties
+#'@description Convert an input string to the most likely source SID
+#' (equivalent to PID.)
+#'@param x a vector, data frame, or tibble of strings representing Wikidata 
+#'source properties.
 #'@return if the inputted string is a valid SID, return the string.
-#'If the inputted string matches a property label, return its SID
-#'If the inputted string matches multiple labels of multiple properties, return the SID of the first hit.
+#'If the inputted string matches a property label, return its SID.
+#'If the inputted string matches multiple labels of multiple properties, 
+#'return the SID of the first hit.
 #'@examples
 #'# if input string is a valid SID
 #'as_pid("S854")
@@ -194,11 +198,15 @@ as_sid <- function(x){
 }
 
 #'@title Add quotations marks
-#'@description Add escaped quotation marks around strings that need them ready for submision to an API
+#'@description Add escaped quotation marks around strings that need them ready for 
+#'submission to an API.
 #'@param x a vector, data frame, or tibble of strings
-#'@param format either "tibble" / "csv" to use plain quotation marks (default), or "api" / "website" to use '\%22'
-#'@return tibble of items inside of escaped quotation marks
-#'unless they are already in escaped quotation marks, is a QID, (in which chase it is returned unchanged) 
+#'@param format either "tibble" / "csv" to use plain quotation marks (default), 
+#'or "api" / "website" to use '\%22'
+#'@return A tibble of items inside of escaped quotation marks
+#'unless they are already in escaped quotation marks, is a 
+#'\href{https://www.wikidata.org/wiki/Q43649390}{QID}, 
+#'in which chase it is returned unchanged. 
 #'@examples
 #'as_quot("text")
 #'@export
@@ -224,11 +232,13 @@ as_quot <- function(x,format="tibble"){
   return(output)
 }
 
-#'@title Extract an identifier from a wikidata URL
+#'@title Extract an identifier from a Wikidata URL
 #'@description Convert a URL ending in an identifier (returned by SPARQL queries)
 #'to just the plan identifier (QID or PID).
-#'@param x a vector of strings representing wikidata URLs
-#'@return QID or PID
+#'@details The \href{https://www.wikidata.org/wiki/Q43649390}{Wikidata Q identifier} (QID) 
+#'is the unique identifier (UID) used in Wikidata.
+#'@param x A vector of strings representing Wikidata URLs.
+#'@return QID or PID.
 #'@examples
 #'url_to_id("http://www.wikidata.org/Q42")
 #'@export
@@ -238,7 +248,7 @@ url_to_id <- function(x){
 
 
 # -------- Wikidata object manipulation --------
-#'@title Extract Claims from Returned Item Data
+#'@title Extract claims from returned item data
 #'@description extract claim information from data returned using
 #'\code{\link{get_item}}.
 #'@param items a list of one or more Wikidata items returned with
@@ -334,6 +344,8 @@ get_names_from_properties <- function(properties){
 #'@title Filter QIDs
 #'@description For a QID or vector of QIDs, remove ones that match a particular statement
 #'(e.g. remove all that are instances of academic publications or books).
+#'@details The \href{https://www.wikidata.org/wiki/Q43649390}{Wikidata Q identifier} (QID) 
+#'is the unique identifier (UID) used in Wikidata.
 #'@param ids QIDs to check
 #'@param property property to check (default = P31 to filter on "instance of")
 #'@param filter values of that property to use to filter out
@@ -457,7 +469,7 @@ unspecial <- function(x){
 
 #'@title Extract a paragraph of text
 #'@description Return the nth paragraph of a section of text
-#'Useful for extracting information from wikipedia or other wikimarkup text
+#'Useful for extracting information from Wikipedia or other wikimarkup text
 #'@param text the input text as a string
 #'@param para number indicating which paragraph(s) to return (default=1)
 #'@param templ an optional string specifying a mediawikitemplate within
@@ -498,7 +510,7 @@ extract_para <- function(text,
 #'@title "CREATE" rows 
 #'@description Add in empty lines for QuickStatements CREATE rows that mint new QIDs.
 #'This is a slightly messy quirk of the QuickStatements format that mints new QIDs via a line
-#'containing only "CREATE", so this function is a way to approximate that bevaviour in a tibble
+#'containing only "CREATE", so this function is a way to approximate that behavior in a tibble
 #'@param items a vector, data frame or tibble of items (which may or may not contain the keyword "CREATE")
 #'@param vector a vector of properties or values which may be expanded based on the items vector
 #'@return if the vector is NULL, return NULL. Otherwise, if the "CREATE" keyword appears in the
@@ -531,8 +543,8 @@ createrows <- function(items,vector){
 #'by any unique ID.
 #'@param QS.tib a tibble of items, values and properties (optionally qualifiers and sources).
 #'@return a tibble, with items that start with "CREATE" followed by any unique text causing the
-#'addition of a "Create" line above, being replaced with "LAST" in the Quickstatemnts format
-#'to create new QIDs.
+#'addition of a "Create" line above, being replaced with "LAST" in the QuickStatements 
+#'format to create new QIDs.
 #'@export
 createrows.tidy <- function(QS.tib){
   #insert 'CREATE' blankrows above first instance of 'CREATExyz'

--- a/R/writes.R
+++ b/R/writes.R
@@ -1,7 +1,7 @@
 # -------- Writes --------
 
 #'@title Write statements to Wikidata
-#'@description Upload data to wikidata, including creating items,
+#'@description Upload data to Wikidata, including creating items,
 #'adding statements to existing items (via the quickstatements format and API).
 #'
 #'@param items a vector of strings indicating the items to which to add statements (as QIDs or labels).
@@ -30,25 +30,25 @@
 #'be removed from the item rather than added (default = FALSE)
 #'@param format output format as a string. Options include:
 #' \describe{
-#'   \item{tibble}{easiest format to further manuipulation in R}
+#'   \item{tibble}{easiest format to further manipulation in R}
 #'   \item{csv}{can be copy-pasted to [the QuickStatements website](https://quickstatements.toolforge.org/) (or manipulated in a spreadsheet programs)}
 #'   \item{api}{a url that can be copy-pasted into a web browser, or automatically submitted (see \code{api.submit} parameter)}
-#'   \item{website}{open a [QuickStatements](https://quickstatements.toolforge.org/) web browser window summarising the edits to be made to Wikidata)}
+#'   \item{website}{open a [QuickStatements](https://quickstatements.toolforge.org/) web browser window summarizing the edits to be made to Wikidata)}
 #' }
-#'@param api.username a string indicating your wikimedia username 
+#'@param api.username a string indicating your Wikimedia username 
 #'@param api.token a string indicating your api token (the unique identifier that you can find listed at [your user page](https://quickstatements.toolforge.org/#/user))
-#'@param api.format a string indicateing which version of the quickstatement format used to submit the api (default = "v1")
+#'@param api.format a string indicating which version of the quickstatement format used to submit the api (default = "v1")
 #'@param api.batchname a string create a named batch (listed at [your batch history page](https://quickstatements.toolforge.org/#/batches)) and tag in the edit summaries
 #'@param api.submit boolian indicating whether to submit instruction directly to wikidata (else returns the URL that can be copy-pasted into a web browser)
 #'
 #'@return data formatted to upload to wikidata (via quickstatemsnts),
-#'optionally also directly uploded to wikidata (see \code{format} parameter). 
+#'optionally also directly uploaded to wikidata (see \code{format} parameter). 
 #'
 #'@examples
 #'# Add a statement to the "Wikidata sandbox" item (Q4115189)
 #'# to say that it is an "instance of" (P31) of Q1 (the universe).
 #'# The instruction will submit directly to wikidata via the API
-#'# (if you include your wikimedia username and token)
+#'# (if you include your Wikimedia username and token)
 #'
 #' \dontrun{write_wikidata(items        = "Wikidata Sandbox",
 #'                properties   = "instance of",

--- a/R/writes_wikibase.R
+++ b/R/writes_wikibase.R
@@ -24,27 +24,27 @@
 #' be removed from the item rather than added (default = FALSE)
 #' @param format output format as a string. Options include:
 #' \describe{
-#'   \item{tibble}{easiest format to further manuipulation in R}
+#'   \item{tibble}{easiest format to further manipulation in R}
 #'   \item{csv}{can be copy-pasted to the Wikibase QuickStatements website (or manipulated in a spreadsheet programs). In contrast to write_wikidata function the delimiter is `tab`, because Quickstatements expect tab-separated data}
 #'   \item{api}{a url that can be copy-pasted into a web browser, or automatically submitted (see \code{api.submit} parameter)}
-#'   \item{website}{open a [QuickStatements](https://quickstatements.toolforge.org/) web browser window summarising the edits to be made to Wikidata)}
+#'   \item{website}{open a [QuickStatements](https://quickstatements.toolforge.org/) web browser window summarizing the edits to be made to Wikidata)}
 #' }
 #' @param format.csv.file path to save the csv file. If none is provided, then printed to console.
-#' @param api.username a string indicating your wikimedia username
+#' @param api.username a string indicating your Wikimedia username
 #' @param api.token a string indicating your api token (the unique identifier that you can find listed at [your user page](https://quickstatements.toolforge.org/#/user))
-#' @param api.format a string indicateing which version of the quickstatement format used to submit the api (default = "v1")
+#' @param api.format a string indicating which version of the quickstatement format used to submit the api (default = "v1")
 #' @param api.batchname a string create a named batch (listed at [your batch history page](https://quickstatements.toolforge.org/#/batches)) and tag in the edit summaries
 #' @param api.submit boolian indicating whether to submit instruction directly to wikidata (else returns the URL that can be copy-pasted into a web browser)
 #' @param quickstatements.url url to access quickstatements of the corresponding Wikibase instance.
 #' @param coordinate_pid PID of a geocoordinates; need to have a different formatting
 #'
-#' @return data formatted to upload to wikidata (via quickstatemsnts),
-#' optionally also directly uploded to wikidata (see \code{format} parameter).
+#' @return data formatted to upload to Wikidata (via quickstatemsnts),
+#' optionally also directly uploaded to Wikidata (see \code{format} parameter).
 #'
 #' @examples
 #' # Add a statement to the "Wikidata sandbox" item (Q4115189)
 #' # to say that it is an "instance of" (P31) of Q1 (the universe).
-#' # The instruction will submit directly to wikidata via the API
+#' # The instruction will submit directly to Wikidata via the API
 #' # (if you include your Wikibase/Wikimedia username and token)
 #'
 #' \dontrun{

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ To get the current development version from github:
 Examples
 ======
 ### Search Wikidata to see if an item exists (example: pharmaceuticals)
-For cases where you don't already know the QID of an item or the PID of a property, you can search wikidata by name. Note that some search terms will return multiple possible items. You can also specify a language (defaults to Engligh).
+For cases where you don't already know the QID of an item or the PID of a property, you can search wikidata by name. Note that some search terms will return multiple possible items. You can also specify a language (defaults to English).
 
 ``` r
 find_item("Paracetamol")
@@ -63,7 +63,7 @@ and
 Elements within those lists include basic information from wikidata (ID, description, labels). The QID or PID can then be used to get the full data for the item (see below).
 
 ### Convert between identifiers
-Wikidata is an excellent thesaurus for different identifiers. For example it's possible to convert from any identifier to wikidata QIDs or between different identifiers
+Wikidata is an excellent thesaurus for different identifiers. For example it is possible to convert from any identifier to wikidata QIDs or between different identifiers
 ``` r
 qid_from_identifier('ISBN-13','978-0-262-53817-6')
 identifier_from_identifier('ORCID iD','IMDb ID',c('0000-0002-7865-7235','0000-0003-1079-5604'))

--- a/man/WD.globalvar.Rd
+++ b/man/WD.globalvar.Rd
@@ -4,7 +4,7 @@
 \alias{WD.globalvar}
 \title{Global variables for Wikidata properties}
 \format{
-A list of tibbles documenting key property constraints from wikidata  
+A list of tibbles documenting key property constraints from Wikidata  
 \describe{
   \item{SID.valid}{valid reference source properties}
   \item{PID.datatype}{required data type for each property}

--- a/man/as_pid.Rd
+++ b/man/as_pid.Rd
@@ -7,10 +7,10 @@
 as_pid(x)
 }
 \arguments{
-\item{x}{a vector, data frame, or tibble of strings representaing wikidata properties}
+\item{x}{a vector, data frame, or tibble of strings representing Wikidata properties}
 }
 \value{
-if the inputted string is a valid PID, return the string.
+If the inputted string is a valid PID, return the string.
 If the inputted string matches a property label, return its PID.
 If the inputted string matches multiple labels of multiple properties, return the PID of the first hit.
 }

--- a/man/as_qid.Rd
+++ b/man/as_qid.Rd
@@ -2,12 +2,12 @@
 % Please edit documentation in R/utils.R
 \name{as_qid}
 \alias{as_qid}
-\title{Convert an input to a item QID}
+\title{Convert an input to a item QID.}
 \usage{
 as_qid(x)
 }
 \arguments{
-\item{x}{a vector, data frame, or tibble of strings representaing wikidata items}
+\item{x}{a vector, data frame, or tibble of strings representing wikidata items}
 }
 \value{
 if the inputted string is a valid QID, return the string.
@@ -15,7 +15,8 @@ If the inputted string matches an item label, return its QID.
 If the inputted string matches multiple labels of multiple items, return the QID of the first hit.
 }
 \description{
-Convert an input string to the most likely item QID
+Convert an input string to the most likely item 
+\href{https://www.wikidata.org/wiki/Q43649390}{QID}.
 }
 \examples{
 # if input string is a valid QID

--- a/man/as_quot.Rd
+++ b/man/as_quot.Rd
@@ -9,14 +9,18 @@ as_quot(x, format = "tibble")
 \arguments{
 \item{x}{a vector, data frame, or tibble of strings}
 
-\item{format}{either "tibble" / "csv" to use plain quotation marks (default), or "api" / "website" to use '\%22'}
+\item{format}{either "tibble" / "csv" to use plain quotation marks (default), 
+or "api" / "website" to use '\%22'}
 }
 \value{
-tibble of items inside of escaped quotation marks
-unless they are already in escaped quotation marks, is a QID, (in which chase it is returned unchanged)
+A tibble of items inside of escaped quotation marks
+unless they are already in escaped quotation marks, is a 
+\href{https://www.wikidata.org/wiki/Q43649390}{QID}, 
+in which chase it is returned unchanged.
 }
 \description{
-Add escaped quotation marks around strings that need them ready for submision to an API
+Add escaped quotation marks around strings that need them ready for 
+submission to an API.
 }
 \examples{
 as_quot("text")

--- a/man/as_sid.Rd
+++ b/man/as_sid.Rd
@@ -7,15 +7,18 @@
 as_sid(x)
 }
 \arguments{
-\item{x}{a vector, data frame, or tibble of strings representaing wikidata source properties}
+\item{x}{a vector, data frame, or tibble of strings representing Wikidata 
+source properties.}
 }
 \value{
 if the inputted string is a valid SID, return the string.
-If the inputted string matches a property label, return its SID
-If the inputted string matches multiple labels of multiple properties, return the SID of the first hit.
+If the inputted string matches a property label, return its SID.
+If the inputted string matches multiple labels of multiple properties, 
+return the SID of the first hit.
 }
 \description{
-Convert an input string to the most likely source SID (equivalent to PID)
+Convert an input string to the most likely source SID
+(equivalent to PID.)
 }
 \examples{
 # if input string is a valid SID

--- a/man/createrows.Rd
+++ b/man/createrows.Rd
@@ -18,5 +18,5 @@ items vector, insert blank strings at those positions in the vector.
 \description{
 Add in empty lines for QuickStatements CREATE rows that mint new QIDs.
 This is a slightly messy quirk of the QuickStatements format that mints new QIDs via a line
-containing only "CREATE", so this function is a way to approximate that bevaviour in a tibble
+containing only "CREATE", so this function is a way to approximate that behavior in a tibble
 }

--- a/man/createrows.tidy.Rd
+++ b/man/createrows.tidy.Rd
@@ -11,8 +11,8 @@ createrows.tidy(QS.tib)
 }
 \value{
 a tibble, with items that start with "CREATE" followed by any unique text causing the
-addition of a "Create" line above, being replaced with "LAST" in the Quickstatemnts format
-to create new QIDs.
+addition of a "Create" line above, being replaced with "LAST" in the QuickStatements 
+format to create new QIDs.
 }
 \description{
 Add in QuickStatements CREATE rows that mint new QIDs from tidy input data.

--- a/man/disambiguate_QIDs.Rd
+++ b/man/disambiguate_QIDs.Rd
@@ -35,7 +35,7 @@ Can also be a list of lists (see examples)}
 
 \item{auto_create}{if no match found, automatically assign "CREATE"}
 
-\item{limit}{number of alternative possible wikidata items to present if multiple potential matches}
+\item{limit}{number of alternative possible Wikidata items to present if multiple potential matches}
 }
 \value{
 a vector of:
@@ -49,8 +49,8 @@ a vector of:
 \description{
 Interactive function that presents alternative possible QID matches for a list of text
 strings and provides options for choosing between alternatives, rejecting all presented alternatives,
-or creating new items. Useful in cases where a list of text strings may have either missing wikidata items
-or multiple alternative potential matches that need to be manually disambuguated. Can also used on
+or creating new items. Useful in cases where a list of text strings may have either missing Wikidata items
+or multiple alternative potential matches that need to be manually disambiguated. Can also used on
 lists of lists (see examples). For long lists of items, the process can be stopped partway through and
 the returned vector will indicate where the process was stopped.
 }

--- a/man/extract_claims.Rd
+++ b/man/extract_claims.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/utils.R
 \name{extract_claims}
 \alias{extract_claims}
-\title{Extract Claims from Returned Item Data}
+\title{Extract claims from returned item data}
 \usage{
 extract_claims(items, claims)
 }

--- a/man/extract_para.Rd
+++ b/man/extract_para.Rd
@@ -19,5 +19,5 @@ the nth paragraph of the input text.
 }
 \description{
 Return the nth paragraph of a section of text
-Useful for extracting information from wikipedia or other wikimarkup text
+Useful for extracting information from Wikipedia or other wikimarkup text
 }

--- a/man/filter_qids.Rd
+++ b/man/filter_qids.Rd
@@ -29,6 +29,10 @@ a vector of QIDs that do not match the property filter
 For a QID or vector of QIDs, remove ones that match a particular statement
 (e.g. remove all that are instances of academic publications or books).
 }
+\details{
+The \href{https://www.wikidata.org/wiki/Q43649390}{Wikidata Q identifier} (QID) 
+is the unique identifier (UID) used in Wikidata.
+}
 \examples{
 \dontrun{
 # Filter three items called "Earth Science" to show only those that aren't

--- a/man/find_item.Rd
+++ b/man/find_item.Rd
@@ -21,18 +21,21 @@ find_property(
 )
 }
 \arguments{
-\item{search_term}{a term to search for.}
+\item{search_term}{A term to search for.}
 
-\item{language}{the language to return the labels and descriptions in; this should
-consist of an ISO language code. Set to "en" by default.}
+\item{language}{The language to return the labels and descriptions in; this should
+consist of an ISO language code. Defaults to \code{"en"}.}
 
-\item{limit}{the number of results to return; set to 10 by default.}
+\item{limit}{The number of results to return; set to \code{10} by default.}
 
-\item{\\dots}{further arguments to pass to httr's GET.}
+\item{\\dots}{further arguments to pass to de{httr:ink[httr::GET]{GET}}.}
+}
+\value{
+A list containing the result of the query.
 }
 \description{
 \code{find_item} and \code{find_property} allow you to retrieve a set
-of Wikidata items or properties where the aliase or descriptions match a particular
+of Wikidata items or properties where the aliases or descriptions match a particular
 search term.  As with other \code{WikidataR} code, custom print methods are available;
 use \code{\link{str}} to manipulate and see the underlying structure of the data.
 }

--- a/man/get_geo_box.Rd
+++ b/man/get_geo_box.Rd
@@ -29,7 +29,7 @@ to \code{city} (eg "NorthWest", "SouthEast").}
 \item{language}{the two-letter language code to use for the name
 of the item. "en" by default.}
 
-\item{\\dots}{further arguments to pass to httr's GET.}
+\item{\\dots}{further arguments to pass to de{httr:ink[httr::GET]{GET}}.}
 }
 \value{
 a data.frame of 5 columns:

--- a/man/get_geo_entity.Rd
+++ b/man/get_geo_entity.Rd
@@ -19,7 +19,7 @@ to restrict the search to.}
 
 \item{limit}{the maximum number of results to return.}
 
-\item{\\dots}{further arguments to pass to httr's GET.}
+\item{\\dots}{further arguments to pass to de{httr:ink[httr::GET]{GET}}.}
 }
 \value{
 a data.frame of 5 columns:

--- a/man/get_item.Rd
+++ b/man/get_item.Rd
@@ -13,10 +13,10 @@ get_property(id, ...)
 \item{id}{the ID number(s) of the item or property you're looking for. This can be in
 various formats; either a numeric value ("200"), the full name ("Q200") or
 even with an included namespace ("Property:P10") - the function will format
-it appropriately. This function is vectorised and will happily accept
+it appropriately. This function is vectorized and will happily accept
 multiple IDs.}
 
-\item{\\dots}{further arguments to pass to httr's GET.}
+\item{\\dots}{further arguments to pass to de{httr:ink[httr::GET]{GET}}.}
 }
 \description{
 \code{get_item} and \code{get_property} allow you to retrieve the data associated

--- a/man/get_random.Rd
+++ b/man/get_random.Rd
@@ -13,7 +13,7 @@ get_random_property(limit = 1, ...)
 \arguments{
 \item{limit}{how many random items to return. 1 by default, but can be higher.}
 
-\item{\\dots}{arguments to pass to httr's GET.}
+\item{\\dots}{arguments to pass to de{httr:ink[httr::GET]{GET}}.}
 }
 \description{
 \code{get_random_item} and \code{get_random_property} allow you to retrieve the data

--- a/man/identifier_from_identifier.Rd
+++ b/man/identifier_from_identifier.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/queries.R
 \name{identifier_from_identifier}
 \alias{identifier_from_identifier}
-\title{identifier from identifier}
+\title{Identifier from identifier}
 \usage{
 identifier_from_identifier(
   property = "ORCID iD",
@@ -11,18 +11,21 @@ identifier_from_identifier(
 )
 }
 \arguments{
-\item{property}{the identifier property to search (for caveats, see \code{as_pid})}
+\item{property}{The identifier property to search (for caveats, see \code{as_pid})}
 
-\item{return}{the identifier property to convert to}
+\item{return}{The identifier property to convert to}
 
-\item{value}{the identifier value to match}
+\item{value}{The identifier value to match.}
 }
 \value{
-vector of identifiers corresponding to identifiers submitted
+A vector of identifiers corresponding to identifiers submitted.
 }
 \description{
-convert unique identifiers to other unique identifiers
+Convert unique identifiers to other unique identifiers.
 }
 \examples{
-identifier_from_identifier('ORCID iD','IMDb ID',c('0000-0002-7865-7235','0000-0003-1079-5604'))
+identifier_from_identifier(property ='ORCID iD',
+                           return = 'IMDb ID',
+                           value = c('0000-0002-7865-7235','0000-0003-1079-5604')
+                           )
 }

--- a/man/print.wikidata.Rd
+++ b/man/print.wikidata.Rd
@@ -7,7 +7,7 @@
 \method{print}{wikidata}(x, ...)
 }
 \arguments{
-\item{x}{wikidata object from get_item, get_random_item, get_property or get_random_property}
+\item{x}{Wikidata object from get_item, get_random_item, get_property or get_random_property}
 
 \item{\dots}{Arguments to be passed to methods}
 }

--- a/man/qid_from_DOI.Rd
+++ b/man/qid_from_DOI.Rd
@@ -13,5 +13,5 @@ qid_from_DOI(DOI = "10.15347/WJM/2019.001")
 vector of QIDs corresponding to DOIs submitted
 }
 \description{
-simple converter from DOIs to QIDs (for items in wikidata)
+simple converter from DOIs to QIDs (for items in Wikidata)
 }

--- a/man/qid_from_identifier.Rd
+++ b/man/qid_from_identifier.Rd
@@ -10,15 +10,19 @@ qid_from_identifier(
 )
 }
 \arguments{
-\item{property}{the identifier property to search (for caveats, see \code{as_pid})}
+\item{property}{The identifier property to search (for caveats, see \code{as_pid}.)}
 
-\item{value}{the identifier value to match}
+\item{value}{The identifier value to match.}
 }
 \value{
-vector of QIDs corresponding to identifiers submitted
+A vector of QIDs corresponding to identifiers submitted.
 }
 \description{
-convert unique identifiers to QIDs (for items in wikidata).
+Convert unique identifiers to QIDs (for items in Wikidata).
+}
+\details{
+The \href{https://www.wikidata.org/wiki/Q43649390}{Wikidata Q identifier} (QID) is the unique identifier (UID) 
+used in Wikidata.
 }
 \examples{
 qid_from_identifier('ISBN-13','978-0-262-53817-6')

--- a/man/query_wikidata.Rd
+++ b/man/query_wikidata.Rd
@@ -12,9 +12,9 @@ query_wikidata(sparql_query, format = "tibble", ...)
 \item{format}{`tibble` (default) returns a pure character data frame,
 `simple` returns a pure character vector, while
 `smart` fetches JSON-formatted data and returns a tibble with datetime
-columns converted to `POSIXct`}
+columns converted to `POSIXct`.}
 
-\item{\\dots}{Additional parameters to supply to [httr::POST]}
+\item{\\dots}{Additional parameters to supply to \code{httr:\link[httr::POST]{POST}}.}
 }
 \value{
 A `tibble` or `vector`. Note: QID values will be returned as QIDs, rather than URLs.
@@ -29,8 +29,8 @@ are also following limits:
 - One client (user agent + IP) is allowed 60 seconds of processing time each
   60 seconds
 - One client is allowed 30 error queries per minute
-See [query limits section](https://www.mediawiki.org/wiki/Wikidata_Query_Service/User_Manual#Query_limits)
-in the WDQS user manual for more information.
+See \href{https://www.mediawiki.org/wiki/Wikidata_Query_Service/User_Manual#Query_limits}{query limits section}
+in the Wikidata Query Service User Manual for more information.
 }
 
 \examples{

--- a/man/sparql_query.Rd
+++ b/man/sparql_query.Rd
@@ -2,19 +2,19 @@
 % Please edit documentation in R/queries.R
 \name{sparql_query}
 \alias{sparql_query}
-\title{Download full Wikidata items matching a sparql query}
+\title{Download full Wikidata items matching a SPARQL query}
 \usage{
 sparql_query(query, ...)
 }
 \arguments{
-\item{query}{the sparql query as a string}
+\item{query}{The SPARQL query as a string}
 
-\item{\\dots}{Additional parameters to supply to [httr::POST]}
+\item{\\dots}{Additional parameters to supply to \code{httr:\link[httr::POST]{POST}}.}
 }
 \value{
 a download of the full wikidata objects formatted as a nested json list
 }
 \description{
-Utility wrapper for wikidata spargle endpoint to download items.
-Used by \code{get_geo_entity} and \code{get_geo_box}
+Utility wrapper for wikidata spargl endpoint to download items.
+Used by \code{get_geo_entity} and \code{get_geo_box}.
 }

--- a/man/url_to_id.Rd
+++ b/man/url_to_id.Rd
@@ -9,12 +9,12 @@ url_to_id(x)
 url_to_id(x)
 }
 \arguments{
-\item{x}{a vector of strings representing wikidata URLs}
+\item{x}{A vector of strings representing Wikidata URLs.}
 }
 \value{
 if the URL ends in a QID or PID, return that PID or QID, else return the original string
 
-QID or PID
+QID or PID.
 }
 \description{
 Convert a URL ending in an identifier (returned by SPARQL queries) to just
@@ -22,6 +22,10 @@ the plain identifier (QID or PID).
 
 Convert a URL ending in an identifier (returned by SPARQL queries)
 to just the plan identifier (QID or PID).
+}
+\details{
+The \href{https://www.wikidata.org/wiki/Q43649390}{Wikidata Q identifier} (QID) 
+is the unique identifier (UID) used in Wikidata.
 }
 \examples{
 url_to_id("http://www.wikidata.org/entity/42")

--- a/man/wd_query.Rd
+++ b/man/wd_query.Rd
@@ -7,14 +7,15 @@
 wd_query(title, ...)
 }
 \arguments{
-\item{title}{the wikidata item or property as a string}
+\item{title}{The Wikidata item or property as a string.}
 
-\item{\\dots}{Additional parameters to supply to [httr::POST]}
+\item{\\dots}{Additional parameters to supply to  \code{httr:\link[httr::POST]{POST}}.}
 }
 \value{
-a download of the full wikidata object (item or property) formatted as a nested json list
+A downloaded full wikidata object (item or property) formatted as a 
+nested json list.
 }
 \description{
-Utility wrapper for wikidata API to download item.
-Used by \code{get_item} and \code{get_property}
+Utility wrapper for Wikidata API to download item.
+Used by \code{get_item} and \code{get_property}.
 }

--- a/man/wd_rand_query.Rd
+++ b/man/wd_rand_query.Rd
@@ -7,15 +7,18 @@
 wd_rand_query(ns, limit, ...)
 }
 \arguments{
-\item{ns}{string indicating namespace, most commonly "Main" for QID items, "Property" for PID properties}
+\item{ns}{string indicating namespace, most commonly "Main" for QID items, "Property" 
+for PID properties.}
 
-\item{limit}{how many random objesct to return}
+\item{limit}{How many random object to return.}
 
-\item{\\dots}{Additional parameters to supply to [httr::POST]}
+\item{\\dots}{Additional parameters to supply to  \code{httr:\link[httr::POST]{POST}}.}
 }
 \value{
-a download of the full wikidata objects (items or properties) formatted as nested json lists
+Downloaded full wikidata objects (items or properties) formatted 
+as nested json lists.
 }
 \description{
-Utility wrapper for wikidata API to download random items. Used by \code{random_item}
+Utility wrapper for Wikidata API to download random items. 
+Used by \code{random_item}.
 }

--- a/man/write_wikibase.Rd
+++ b/man/write_wikibase.Rd
@@ -55,19 +55,19 @@ be removed from the item rather than added (default = FALSE)}
 
 \item{format}{output format as a string. Options include:
 \describe{
-  \item{tibble}{easiest format to further manuipulation in R}
+  \item{tibble}{easiest format to further manipulation in R}
   \item{csv}{can be copy-pasted to the Wikibase QuickStatements website (or manipulated in a spreadsheet programs). In contrast to write_wikidata function the delimiter is `tab`, because Quickstatements expect tab-separated data}
   \item{api}{a url that can be copy-pasted into a web browser, or automatically submitted (see \code{api.submit} parameter)}
-  \item{website}{open a [QuickStatements](https://quickstatements.toolforge.org/) web browser window summarising the edits to be made to Wikidata)}
+  \item{website}{open a [QuickStatements](https://quickstatements.toolforge.org/) web browser window summarizing the edits to be made to Wikidata)}
 }}
 
 \item{format.csv.file}{path to save the csv file. If none is provided, then printed to console.}
 
-\item{api.username}{a string indicating your wikimedia username}
+\item{api.username}{a string indicating your Wikimedia username}
 
 \item{api.token}{a string indicating your api token (the unique identifier that you can find listed at [your user page](https://quickstatements.toolforge.org/#/user))}
 
-\item{api.format}{a string indicateing which version of the quickstatement format used to submit the api (default = "v1")}
+\item{api.format}{a string indicating which version of the quickstatement format used to submit the api (default = "v1")}
 
 \item{api.batchname}{a string create a named batch (listed at [your batch history page](https://quickstatements.toolforge.org/#/batches)) and tag in the edit summaries}
 
@@ -78,8 +78,8 @@ be removed from the item rather than added (default = FALSE)}
 \item{coordinate_pid}{PID of a geocoordinates; need to have a different formatting}
 }
 \value{
-data formatted to upload to wikidata (via quickstatemsnts),
-optionally also directly uploded to wikidata (see \code{format} parameter).
+data formatted to upload to Wikidata (via quickstatemsnts),
+optionally also directly uploaded to Wikidata (see \code{format} parameter).
 }
 \description{
 Upload data to a Wikibase instance, including creating items,
@@ -88,7 +88,7 @@ adding statements to existing items (via the quickstatements format and API).
 \examples{
 # Add a statement to the "Wikidata sandbox" item (Q4115189)
 # to say that it is an "instance of" (P31) of Q1 (the universe).
-# The instruction will submit directly to wikidata via the API
+# The instruction will submit directly to Wikidata via the API
 # (if you include your Wikibase/Wikimedia username and token)
 
 \dontrun{

--- a/man/write_wikidata.Rd
+++ b/man/write_wikidata.Rd
@@ -56,17 +56,17 @@ be removed from the item rather than added (default = FALSE)}
 
 \item{format}{output format as a string. Options include:
 \describe{
-  \item{tibble}{easiest format to further manuipulation in R}
+  \item{tibble}{easiest format to further manipulation in R}
   \item{csv}{can be copy-pasted to [the QuickStatements website](https://quickstatements.toolforge.org/) (or manipulated in a spreadsheet programs)}
   \item{api}{a url that can be copy-pasted into a web browser, or automatically submitted (see \code{api.submit} parameter)}
-  \item{website}{open a [QuickStatements](https://quickstatements.toolforge.org/) web browser window summarising the edits to be made to Wikidata)}
+  \item{website}{open a [QuickStatements](https://quickstatements.toolforge.org/) web browser window summarizing the edits to be made to Wikidata)}
 }}
 
-\item{api.username}{a string indicating your wikimedia username}
+\item{api.username}{a string indicating your Wikimedia username}
 
 \item{api.token}{a string indicating your api token (the unique identifier that you can find listed at [your user page](https://quickstatements.toolforge.org/#/user))}
 
-\item{api.format}{a string indicateing which version of the quickstatement format used to submit the api (default = "v1")}
+\item{api.format}{a string indicating which version of the quickstatement format used to submit the api (default = "v1")}
 
 \item{api.batchname}{a string create a named batch (listed at [your batch history page](https://quickstatements.toolforge.org/#/batches)) and tag in the edit summaries}
 
@@ -74,17 +74,17 @@ be removed from the item rather than added (default = FALSE)}
 }
 \value{
 data formatted to upload to wikidata (via quickstatemsnts),
-optionally also directly uploded to wikidata (see \code{format} parameter).
+optionally also directly uploaded to wikidata (see \code{format} parameter).
 }
 \description{
-Upload data to wikidata, including creating items,
+Upload data to Wikidata, including creating items,
 adding statements to existing items (via the quickstatements format and API).
 }
 \examples{
 # Add a statement to the "Wikidata sandbox" item (Q4115189)
 # to say that it is an "instance of" (P31) of Q1 (the universe).
 # The instruction will submit directly to wikidata via the API
-# (if you include your wikimedia username and token)
+# (if you include your Wikimedia username and token)
 
 \dontrun{write_wikidata(items        = "Wikidata Sandbox",
                properties   = "instance of",


### PR DESCRIPTION
I would like to make some more meaningful commits, but I found the documentation and the code hard to read, so I thought first I would make a pull request with very obvious changes.  None of the changes modify any code.

- Plenty of spelling mistakes are corrected.
- Because the DESCRIPTION sets the spelling to en-US, en-GB spelling was modified to en-US (when multiple uses were present.)
- Some missing Roxygen fields (such as missing @return) values are inserted. In the next CRAN release, this would have triggered a review. 
- When functions were referenced from another package, such as httr::POST, the manual was changed to \code{httr:\link[httr::POST]{POST}} so that manuals are linked per CRAN policy.
- In some cases, I added concise extra URL links or details, particularly with abbreviations that may put off a first-time user; for example, I linked or entirely wrote out QID as Wikidata Q ID (unique ID in Wikidata), linking the official definition.
- Also linked the Wikidata Query Statement Manual with URL.
- When the code or documentation lines exceeded 100 characters, I added extra indentation for code readability.
- When Wikidata was referenced in the text, it followed either the official, capitalized Wikidata spelling or wikidata, I made it Wikidata in the documentation (of course, not in the code and URLs.)

There are a few non-obvious changes that I did not make without asking.
- It would make sense to use usethis::use_spell_check to avoid piling up again hundreds of typos.
- The README is already quite long, but some expressions are not explained to a new user of Wikidata.  I think it would make sense to re-write it with extra detail into 2-3 vignette articles, largely following with a more detailed explanation of the current code divisions, for example, writing a vignette with examples on how to find things on Wikidata programmatically with the Package.
- There are some good coding practices and intentendation rules that would make the code easier to read for a new contributor and improve without changing code functionality. 
- It would be good to add a pkgdown website and install a long-form, standard, HTML manual which is far easier to read than the PDF manual.



